### PR TITLE
Several quality of life features

### DIFF
--- a/src/main/java/io/github/thegatesdev/maple/ElementType.java
+++ b/src/main/java/io/github/thegatesdev/maple/ElementType.java
@@ -23,15 +23,15 @@ public enum ElementType {
     /**
      * The map element type, corresponding to the {@link io.github.thegatesdev.maple.element.DataMap} class.
      */
-    MAP("dataMap", "a map element"),
+    MAP("dataMap", "map"),
     /**
      * The list element type, corresponding to the {@link io.github.thegatesdev.maple.element.DataList} class.
      */
-    LIST("dataList", "a list element"),
+    LIST("dataList", "list"),
     /**
      * The value element type, corresponding to the {@link io.github.thegatesdev.maple.element.DataValue} interface.
      */
-    VALUE("dataValue", "a value element");
+    VALUE("dataValue", "value");
 
 
     private final String elementName, inlineName;

--- a/src/main/java/io/github/thegatesdev/maple/element/DataDictionary.java
+++ b/src/main/java/io/github/thegatesdev/maple/element/DataDictionary.java
@@ -202,6 +202,20 @@ public sealed interface DataDictionary<Key> permits DataMap, DataList {
         return get(key).asMap();
     }
 
+
+    /**
+     * Get the map element at the given key. Returns the given default value when it is not present.
+     *
+     * @param key the key for the element
+     * @param def the default value
+     * @return the map element
+     */
+    default DataMap getMap(Key key, DataMap def){
+        DataElement el = find(key);
+        if (el == null || !el.isMap()) return def;
+        return el.asMap();
+    }
+
     /**
      * Get the list element at the given key.
      *
@@ -213,6 +227,19 @@ public sealed interface DataDictionary<Key> permits DataMap, DataList {
     }
 
     /**
+     * Get the list element at the given key. Returns the given default value when it is not present.
+     *
+     * @param key the key for the element
+     * @param def the default value
+     * @return the list element
+     */
+    default DataList getList(Key key, DataList def){
+        DataElement el = find(key);
+        if (el == null || !el.isList()) return def;
+        return el.asList();
+    }
+
+    /**
      * Get the value element at the given key.
      *
      * @param key the key for the element
@@ -220,6 +247,19 @@ public sealed interface DataDictionary<Key> permits DataMap, DataList {
      */
     default DataValue<?> getValue(Key key) {
         return get(key).asValue();
+    }
+
+    /**
+     * Get the value element at the given key. Returns the given default value when it is not present.
+     *
+     * @param key the key for the element
+     * @param def the default value
+     * @return the value element
+     */
+    default DataValue<?> getValue(Key key, DataValue<?> def){
+        DataElement el = find(key);
+        if (el == null || !el.isValue()) return def;
+        return el.asValue();
     }
 
     // Iteration

--- a/src/main/java/io/github/thegatesdev/maple/element/DataDictionary.java
+++ b/src/main/java/io/github/thegatesdev/maple/element/DataDictionary.java
@@ -320,6 +320,14 @@ public sealed interface DataDictionary<Key> permits DataMap, DataList {
     List<DataElement> collect();
 
     /**
+     * Obtain a list element holding the values of this dictionary.
+     * May return the same object.
+     *
+     * @return the list with values
+     */
+    DataList valueList();
+
+    /**
      * Collect the elements in this dictionary to a new, modifiable list after applying the given function.
      *
      * @param mapper the function to apply to each element

--- a/src/main/java/io/github/thegatesdev/maple/element/DataDictionary.java
+++ b/src/main/java/io/github/thegatesdev/maple/element/DataDictionary.java
@@ -18,8 +18,13 @@ package io.github.thegatesdev.maple.element;
 
 import io.github.thegatesdev.maple.exception.KeyNotPresentException;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public sealed interface DataDictionary<Key> permits DataMap, DataList {
 
@@ -297,6 +302,32 @@ public sealed interface DataDictionary<Key> permits DataMap, DataList {
      */
     default void eachValue(Consumer<DataValue<?>> valueConsumer) {
         each(element -> element.ifValue(valueConsumer));
+    }
+
+
+    /**
+     * Create a stream from the elements in this dictionary.
+     *
+     * @return the new stream
+     */
+    Stream<DataElement> stream();
+
+    /**
+     * Collect the elements in this dictionary to a new, modifiable list.
+     *
+     * @return the new list
+     */
+    List<DataElement> collect();
+
+    /**
+     * Collect the elements in this dictionary to a new, modifiable list after applying the given function.
+     *
+     * @param mapper the function to apply to each element
+     * @return the new list
+     */
+    default <T> List<T> collect(Function<DataElement, T> mapper){
+        // Highly naive implementation... should be overridden.
+        return stream().map(mapper).collect(Collectors.toCollection(ArrayList::new));
     }
 
     // Information

--- a/src/main/java/io/github/thegatesdev/maple/element/DataList.java
+++ b/src/main/java/io/github/thegatesdev/maple/element/DataList.java
@@ -114,6 +114,11 @@ public final class DataList implements DataElement, DataDictionary<Integer> {
         return result;
     }
 
+    @Override
+    public DataList valueList() {
+        return this;
+    }
+
     // Information
 
     @Override

--- a/src/main/java/io/github/thegatesdev/maple/element/DataList.java
+++ b/src/main/java/io/github/thegatesdev/maple/element/DataList.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * An element holding a list of elements.
@@ -93,6 +94,24 @@ public final class DataList implements DataElement, DataDictionary<Integer> {
         for (int i = 0; i < elements.length; i++)
             output[i] = transformFunction.apply(elements[i]);
         return new DataList(output);
+    }
+
+    @Override
+    public Stream<DataElement> stream() {
+        return Arrays.stream(elements);
+    }
+
+    @Override
+    public List<DataElement> collect() {
+        return new ArrayList<>(Arrays.asList(elements));
+    }
+
+    @Override
+    public <T> List<T> collect(Function<DataElement, T> mapper) {
+        var result = new ArrayList<T>(elements.length);
+        for (final DataElement element : elements)
+            result.add(mapper.apply(element));
+        return result;
     }
 
     // Information

--- a/src/main/java/io/github/thegatesdev/maple/element/DataMap.java
+++ b/src/main/java/io/github/thegatesdev/maple/element/DataMap.java
@@ -101,6 +101,24 @@ public final class DataMap implements DataElement, DataDictionary<String> {
         return result;
     }
 
+    /**
+     * Obtain a list element holding the keys of this map element.
+     *
+     * @return the list with keys
+     */
+    public DataList keyList(){
+        var builder = DataList.builder(size());
+        elements.keySet().forEach(key -> builder.add(DataValue.of(key)));
+        return builder.build();
+    }
+
+    @Override
+    public DataList valueList(){
+        var builder = DataList.builder(size());
+        builder.addFrom(elements.values());
+        return builder.build();
+    }
+
     // Information
 
     @Override

--- a/src/main/java/io/github/thegatesdev/maple/element/DataMap.java
+++ b/src/main/java/io/github/thegatesdev/maple/element/DataMap.java
@@ -18,12 +18,10 @@ package io.github.thegatesdev.maple.element;
 
 import io.github.thegatesdev.maple.ElementType;
 
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * An element mapping {@code String} keys to {@code DataValue} values.
@@ -84,6 +82,23 @@ public final class DataMap implements DataElement, DataDictionary<String> {
         elements.forEach((key, value) ->
                 builder.add(key, transformFunction.apply(value)));
         return builder.build();
+    }
+
+    @Override
+    public Stream<DataElement> stream() {
+        return elements.values().stream();
+    }
+
+    @Override
+    public List<DataElement> collect() {
+        return new ArrayList<>(elements.values());
+    }
+
+    @Override
+    public <T> List<T> collect(Function<DataElement, T> mapper) {
+        var result = new ArrayList<T>(elements.size());
+        elements.forEach((s, element) -> result.add(mapper.apply(element)));
+        return result;
     }
 
     // Information

--- a/src/main/java/io/github/thegatesdev/maple/exception/ElementTypeException.java
+++ b/src/main/java/io/github/thegatesdev/maple/exception/ElementTypeException.java
@@ -23,7 +23,7 @@ import io.github.thegatesdev.maple.ElementType;
  */
 public class ElementTypeException extends IllegalArgumentException {
 
-    private static final String MESSAGE = "Invalid element type, expected %s, got %s";
+    private static final String MESSAGE = "Invalid element type, expected a %s, got a %s";
     private final ElementType expectedType, actualType;
 
     /**

--- a/src/main/java/io/github/thegatesdev/maple/read/types/EnumDataType.java
+++ b/src/main/java/io/github/thegatesdev/maple/read/types/EnumDataType.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * DataType representing an enum.
+ * DataType representing a string as an enum value.
  * Caches all types.
  */
 public class EnumDataType<E extends Enum<E>> implements DataType<DataValue<E>> {

--- a/src/main/java/io/github/thegatesdev/maple/read/types/ValueDataType.java
+++ b/src/main/java/io/github/thegatesdev/maple/read/types/ValueDataType.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * DataType representing a value type.
+ * DataType representing a simple value of the given type.
  * Caches all types.
  */
 public class ValueDataType<Val> implements DataType<DataValue<Val>> {


### PR DESCRIPTION
This PR implements a couple quality of life improvements for problems I came across while using version 4.0.0 in a plugin project.

- Dictionary getters like `getMap` now have a method accepting a default value.
- Added `stream`, `collect` and `valueList` methods to dictionaries, and `keyList` to the map element.
- Make `DefaultConversion` class extendable.
- The ElementType enum `inlineName` property now doesn't contain the articles and "element" for the string, e.g. "a map element" has become "map".