### PR TITLE
Version 4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![maple-banner-plain](https://github.com/thegatesdev/maple/assets/69715898/16368197-a6e0-4edf-9df4-2576db370412)
 
-A simple, type safe configuration structure
+A clean, type safe intermediary structure
 
-*Updated for version 4.0.0*
+*Updated for version 4.1.0*
 
 ## Contents
 
@@ -63,7 +63,7 @@ DataElement myElement = DataMap.EMPTY;
 myElement.isList(); // False
 myElement.isMap(); // True
 
-myElement.type(); // ElementType.MAP
+ElementType type = myElement.type(); // ElementType.MAP
 
 myElement.ifMap(map -> print("myElement is a map!"), () -> print("myElement is not a map!"));
 ```
@@ -79,7 +79,7 @@ DataMap myMap;
 DataElement otherElement = myMap.get("somekey");
 
 DataMap otherMap = myMap.getMap("mapkey");
-DataList otherList = myMap.getList("listkey");
+DataList otherList = myMap.getList("listkey", DataList.EMTPY); // With default
 
 DataElement optionalElement = myMap.find("invalid_key"); // Returns 'null' if not found
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,21 +5,21 @@ plugins {
 }
 
 group = "io.github.thegatesdev"
-version = "4.0.0"
+version = "4.1.0"
 description = "A clean, type safe configuration structure."
 
-repositories{
+repositories {
     mavenCentral()
 }
 
-dependencies{
+dependencies {
     testImplementation(platform("org.junit:junit-bom:5.10.1"))
     testImplementation("org.junit.jupiter:junit-jupiter")
 }
 
 
-tasks{
-    test{
+tasks {
+    test {
         useJUnitPlatform()
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 group = "io.github.thegatesdev"
 version = "4.1.0"
-description = "A clean, type safe configuration structure."
+description = "A clean, type safe intermediary structure"
 
 repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,22 @@ group = "io.github.thegatesdev"
 version = "4.0.0"
 description = "A clean, type safe configuration structure."
 
+repositories{
+    mavenCentral()
+}
+
+dependencies{
+    testImplementation(platform("org.junit:junit-bom:5.10.1"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+}
+
+
+tasks{
+    test{
+        useJUnitPlatform()
+    }
+}
+
 
 java {
     withJavadocJar()

--- a/src/main/java/io/github/thegatesdev/maple/ElementType.java
+++ b/src/main/java/io/github/thegatesdev/maple/ElementType.java
@@ -23,15 +23,15 @@ public enum ElementType {
     /**
      * The map element type, corresponding to the {@link io.github.thegatesdev.maple.element.DataMap} class.
      */
-    MAP("dataMap", "a map element"),
+    MAP("dataMap", "map"),
     /**
      * The list element type, corresponding to the {@link io.github.thegatesdev.maple.element.DataList} class.
      */
-    LIST("dataList", "a list element"),
+    LIST("dataList", "list"),
     /**
      * The value element type, corresponding to the {@link io.github.thegatesdev.maple.element.DataValue} interface.
      */
-    VALUE("dataValue", "a value element");
+    VALUE("dataValue", "value");
 
 
     private final String elementName, inlineName;

--- a/src/main/java/io/github/thegatesdev/maple/element/DataDictionary.java
+++ b/src/main/java/io/github/thegatesdev/maple/element/DataDictionary.java
@@ -18,8 +18,13 @@ package io.github.thegatesdev.maple.element;
 
 import io.github.thegatesdev.maple.exception.KeyNotPresentException;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public sealed interface DataDictionary<Key> permits DataMap, DataList {
 
@@ -202,6 +207,20 @@ public sealed interface DataDictionary<Key> permits DataMap, DataList {
         return get(key).asMap();
     }
 
+
+    /**
+     * Get the map element at the given key. Returns the given default value when it is not present.
+     *
+     * @param key the key for the element
+     * @param def the default value
+     * @return the map element
+     */
+    default DataMap getMap(Key key, DataMap def){
+        DataElement el = find(key);
+        if (el == null || !el.isMap()) return def;
+        return el.asMap();
+    }
+
     /**
      * Get the list element at the given key.
      *
@@ -213,6 +232,19 @@ public sealed interface DataDictionary<Key> permits DataMap, DataList {
     }
 
     /**
+     * Get the list element at the given key. Returns the given default value when it is not present.
+     *
+     * @param key the key for the element
+     * @param def the default value
+     * @return the list element
+     */
+    default DataList getList(Key key, DataList def){
+        DataElement el = find(key);
+        if (el == null || !el.isList()) return def;
+        return el.asList();
+    }
+
+    /**
      * Get the value element at the given key.
      *
      * @param key the key for the element
@@ -220,6 +252,19 @@ public sealed interface DataDictionary<Key> permits DataMap, DataList {
      */
     default DataValue<?> getValue(Key key) {
         return get(key).asValue();
+    }
+
+    /**
+     * Get the value element at the given key. Returns the given default value when it is not present.
+     *
+     * @param key the key for the element
+     * @param def the default value
+     * @return the value element
+     */
+    default DataValue<?> getValue(Key key, DataValue<?> def){
+        DataElement el = find(key);
+        if (el == null || !el.isValue()) return def;
+        return el.asValue();
     }
 
     // Iteration
@@ -257,6 +302,40 @@ public sealed interface DataDictionary<Key> permits DataMap, DataList {
      */
     default void eachValue(Consumer<DataValue<?>> valueConsumer) {
         each(element -> element.ifValue(valueConsumer));
+    }
+
+
+    /**
+     * Create a stream from the elements in this dictionary.
+     *
+     * @return the new stream
+     */
+    Stream<DataElement> stream();
+
+    /**
+     * Collect the elements in this dictionary to a new, modifiable list.
+     *
+     * @return the new list
+     */
+    List<DataElement> collect();
+
+    /**
+     * Obtain a list element holding the values of this dictionary.
+     * May return the same object.
+     *
+     * @return the list with values
+     */
+    DataList valueList();
+
+    /**
+     * Collect the elements in this dictionary to a new, modifiable list after applying the given function.
+     *
+     * @param mapper the function to apply to each element
+     * @return the new list
+     */
+    default <T> List<T> collect(Function<DataElement, T> mapper){
+        // Highly naive implementation... should be overridden.
+        return stream().map(mapper).collect(Collectors.toCollection(ArrayList::new));
     }
 
     // Information

--- a/src/main/java/io/github/thegatesdev/maple/element/DataList.java
+++ b/src/main/java/io/github/thegatesdev/maple/element/DataList.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * An element holding a list of elements.
@@ -93,6 +94,29 @@ public final class DataList implements DataElement, DataDictionary<Integer> {
         for (int i = 0; i < elements.length; i++)
             output[i] = transformFunction.apply(elements[i]);
         return new DataList(output);
+    }
+
+    @Override
+    public Stream<DataElement> stream() {
+        return Arrays.stream(elements);
+    }
+
+    @Override
+    public List<DataElement> collect() {
+        return new ArrayList<>(Arrays.asList(elements));
+    }
+
+    @Override
+    public <T> List<T> collect(Function<DataElement, T> mapper) {
+        var result = new ArrayList<T>(elements.length);
+        for (final DataElement element : elements)
+            result.add(mapper.apply(element));
+        return result;
+    }
+
+    @Override
+    public DataList valueList() {
+        return this;
     }
 
     // Information

--- a/src/main/java/io/github/thegatesdev/maple/element/DataMap.java
+++ b/src/main/java/io/github/thegatesdev/maple/element/DataMap.java
@@ -18,12 +18,10 @@ package io.github.thegatesdev.maple.element;
 
 import io.github.thegatesdev.maple.ElementType;
 
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * An element mapping {@code String} keys to {@code DataValue} values.
@@ -83,6 +81,41 @@ public final class DataMap implements DataElement, DataDictionary<String> {
         var builder = builder(size());
         elements.forEach((key, value) ->
                 builder.add(key, transformFunction.apply(value)));
+        return builder.build();
+    }
+
+    @Override
+    public Stream<DataElement> stream() {
+        return elements.values().stream();
+    }
+
+    @Override
+    public List<DataElement> collect() {
+        return new ArrayList<>(elements.values());
+    }
+
+    @Override
+    public <T> List<T> collect(Function<DataElement, T> mapper) {
+        var result = new ArrayList<T>(elements.size());
+        elements.forEach((s, element) -> result.add(mapper.apply(element)));
+        return result;
+    }
+
+    /**
+     * Obtain a list element holding the keys of this map element.
+     *
+     * @return the list with keys
+     */
+    public DataList keyList(){
+        var builder = DataList.builder(size());
+        elements.keySet().forEach(key -> builder.add(DataValue.of(key)));
+        return builder.build();
+    }
+
+    @Override
+    public DataList valueList(){
+        var builder = DataList.builder(size());
+        builder.addFrom(elements.values());
         return builder.build();
     }
 

--- a/src/main/java/io/github/thegatesdev/maple/exception/ElementTypeException.java
+++ b/src/main/java/io/github/thegatesdev/maple/exception/ElementTypeException.java
@@ -23,7 +23,7 @@ import io.github.thegatesdev.maple.ElementType;
  */
 public class ElementTypeException extends IllegalArgumentException {
 
-    private static final String MESSAGE = "Invalid element type, expected %s, got %s";
+    private static final String MESSAGE = "Invalid element type, expected a %s, got a %s";
     private final ElementType expectedType, actualType;
 
     /**

--- a/src/main/java/io/github/thegatesdev/maple/read/types/EnumDataType.java
+++ b/src/main/java/io/github/thegatesdev/maple/read/types/EnumDataType.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * DataType representing an enum.
+ * DataType representing a string as an enum value.
  * Caches all types.
  */
 public class EnumDataType<E extends Enum<E>> implements DataType<DataValue<E>> {

--- a/src/main/java/io/github/thegatesdev/maple/read/types/ValueDataType.java
+++ b/src/main/java/io/github/thegatesdev/maple/read/types/ValueDataType.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * DataType representing a value type.
+ * DataType representing a simple value of the given type.
  * Caches all types.
  */
 public class ValueDataType<Val> implements DataType<DataValue<Val>> {

--- a/src/test/java/io/github/thegatesdev/maple/DataDictionaryTest.java
+++ b/src/test/java/io/github/thegatesdev/maple/DataDictionaryTest.java
@@ -1,0 +1,102 @@
+package io.github.thegatesdev.maple;
+
+import io.github.thegatesdev.maple.element.DataElement;
+import io.github.thegatesdev.maple.element.DataList;
+import io.github.thegatesdev.maple.element.DataMap;
+import io.github.thegatesdev.maple.element.DataValue;
+import io.github.thegatesdev.maple.exception.ElementTypeException;
+import io.github.thegatesdev.maple.exception.KeyNotPresentException;
+import io.github.thegatesdev.maple.exception.ValueTypeException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+class DataDictionaryTest {
+
+    private static DataMap testMap;
+    private static DataList testList;
+
+    @BeforeAll
+    static void setupTestMap() {
+        testMap = DataMap.builder(3)
+                .add("key_one", DataValue.of("value_one"))
+                .add("key_two", DataList.EMPTY)
+                .add("key_three", DataMap.builder().add("key_nested", DataValue.of("value_nested")).build())
+                .build();
+    }
+
+    @BeforeAll
+    static void setupTestList() {
+        testList = DataList.builder(3)
+                .add(DataValue.of("value_one"))
+                .add(DataList.EMPTY)
+                .add(DataMap.builder().add("key_nested", DataValue.of("value_nested")).build())
+                .build();
+    }
+
+
+    @Test
+    void whenElementPresent_thenElementGet() {
+        Assertions.assertDoesNotThrow(() -> testMap.get("key_one"));
+        Assertions.assertDoesNotThrow(() -> testMap.get("key_two"));
+        Assertions.assertDoesNotThrow(() -> testList.get(0));
+        Assertions.assertDoesNotThrow(() -> testList.get(1));
+    }
+
+    @Test
+    void whenNotMapElement_thenThrowOrNull() {
+        Assertions.assertThrows(KeyNotPresentException.class, () -> testMap.get("key_invalid"));
+        Assertions.assertNull(testMap.find("key_invalid"));
+        Assertions.assertThrows(KeyNotPresentException.class, () -> testList.get(4));
+        Assertions.assertNull(testList.find(4));
+    }
+
+    @Test
+    void whenInvalidElementType_thenThrow() {
+        Assertions.assertThrows(ElementTypeException.class, () -> testMap.getMap("key_one"));
+        Assertions.assertDoesNotThrow(() -> testMap.getList("key_two"));
+        Assertions.assertThrows(ElementTypeException.class, () -> testList.getMap(0));
+        Assertions.assertDoesNotThrow(() -> testList.getList(1));
+    }
+
+    @Test
+    void whenInvalidValueType_thenThrowOrDefault() {
+        Assertions.assertThrows(ValueTypeException.class, () -> testMap.getInt("key_one"));
+        Assertions.assertEquals(testMap.getInt("key_one", 1), 1);
+        Assertions.assertThrows(ValueTypeException.class, () -> testList.getInt(0));
+        Assertions.assertEquals(testList.getInt(0, 1), 1);
+    }
+
+    @Test
+    void whenTransforming_visitOnlyChildren() {
+        Assertions.assertEquals(transformCount(testMap), 3);
+        Assertions.assertEquals(transformCount(testList), 3);
+    }
+
+    @Test
+    void whenCrawlingMap_visitAllDescendants() {
+        Assertions.assertEquals(crawlCount(testMap), 4);
+        Assertions.assertEquals(crawlCount(testList), 4);
+    }
+
+
+    private static int crawlCount(DataElement element) {
+        final AtomicInteger visited = new AtomicInteger();
+        element.crawl(val -> {
+            visited.getAndIncrement();
+            return val;
+        });
+        return visited.get();
+    }
+
+    private static int transformCount(DataElement element) {
+        final AtomicInteger visited = new AtomicInteger();
+        element.transform(val -> {
+            visited.getAndIncrement();
+            return val;
+        });
+        return visited.get();
+    }
+}

--- a/src/test/java/io/github/thegatesdev/maple/MapOptionsTest.java
+++ b/src/test/java/io/github/thegatesdev/maple/MapOptionsTest.java
@@ -1,0 +1,54 @@
+package io.github.thegatesdev.maple;
+
+import io.github.thegatesdev.maple.element.DataList;
+import io.github.thegatesdev.maple.element.DataMap;
+import io.github.thegatesdev.maple.element.DataValue;
+import io.github.thegatesdev.maple.exception.KeyNotPresentException;
+import io.github.thegatesdev.maple.read.DataType;
+import io.github.thegatesdev.maple.read.MapOptions;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class MapOptionsTest {
+
+    private static MapOptions<DataMap> testOptions;
+
+    @BeforeAll
+    static void setupTestOptions() {
+        testOptions = MapOptions.builder()
+                .add("option_one", DataType.integer())
+                .add("option_two", DataType.bool(), false)
+                .add("option_three", DataType.string().listType())
+                .add("option_four", DataType.enumeration(ElementType.class), ElementType.MAP)
+                .build();
+    }
+
+    @Test
+    void whenCorrectOptions_thenValidate() {
+        Assertions.assertDoesNotThrow(() -> testOptions.apply(DataMap.builder()
+                .add("option_one", DataValue.of(1))
+                .add("option_two", DataValue.of(true))
+                .add("option_three", DataList.builder().add(DataValue.of("string_value")).build())
+                .build()));
+    }
+
+    @Test
+    void whenOptionNotPresent_thenThrow() {
+        Assertions.assertThrows(KeyNotPresentException.class,
+                () -> testOptions.apply(DataMap.builder()
+                        .add("option_two", DataValue.of(true))
+                        .add("option_three", DataList.builder().add(DataValue.of("string_value")).build())
+                        .build()));
+    }
+
+    @Test
+    void whenDefaultedOptionNotPresent_thenDefault() {
+        DataMap result = testOptions.apply(DataMap.builder()
+                .add("option_one", DataValue.of(1))
+                .add("option_three", DataList.builder().add(DataValue.of("string_value")).build())
+                .build());
+        Assertions.assertEquals(result.getBool("option_two"), false);
+        Assertions.assertEquals(result.get("option_four", ElementType.class), ElementType.MAP);
+    }
+}


### PR DESCRIPTION
Update version 4.1.0 with added tests and quality of life improvements and additions.

- #7
- #6

I have several things in mind for a version 5 release, notably:
- Unify the `get` and `find` methods to either throw, or return `Optional`'s respectively. (They're a bit messy currently)
- Make `DataValue` handle simple conversion between numbers and strings (or parse both int and string from the start if possible)
- Somehow define more clearly what kind of data is stored. This comes from the problem that maple elements can both represent *plain config data types* which are just read from a configuration file (Strings, ints, etc.), or *actual usable objects* that are put into, or transformed from configuration values (Enums and any other object types). There is two possible approaches I see there:
    - Maple doesn't care about what types are stored, the user needs to handle that correctly. This means that Maple cannot implement a 2 way conversion.
    - Maple somehow represents all types of data, and can convert between 'config/semi-serialized' and 'application' types.